### PR TITLE
Add `let assert` syntax

### DIFF
--- a/src/main/antlr/Gleam.g4
+++ b/src/main/antlr/Gleam.g4
@@ -134,7 +134,7 @@ useArgs: identifier | identifier COMMA useArgs;
 use: USE (useArgs)? L_ARROW expression;
 
 assignment: pattern (typeAnnotation)? EQ expression;
-let: LET assignment;
+let: LET ASSERT? assignment;
 assert: ASSERT assignment;
 negation: BANG expressionUnit;
 


### PR DESCRIPTION
Just a small patch that enables the `let assert` syntax.
With this PR statements like the following are correctly parsed and highlighted:
```gleam
let assert Ok(_) =
  wisp.mist_handler(handler, secret_key_base)
  |> mist.new
  |> mist.port(8000)
  |> mist.start_http
```